### PR TITLE
[Fix]"Load From Directory" Node's "Respond To Asset Change" change is not saved

### DIFF
--- a/UnityEngine.AssetGraph/Editor/System/Node/Buitin/Loader.cs
+++ b/UnityEngine.AssetGraph/Editor/System/Node/Buitin/Loader.cs
@@ -188,6 +188,7 @@ namespace UnityEngine.AssetGraph {
             if (bRespondAP != m_respondToAssetChange) {
                 using (new RecordUndoScope ("Remove Target Load Path Settings", node, true)) {
                     m_respondToAssetChange = bRespondAP;
+                    onValueChanged();
                 }
             }
 


### PR DESCRIPTION
- Fixed bug: "Load From Directory" Node's "Respond To Asset Change" change is not saved.
   - Call `onValueChanged()` when `m_respondToAssetChange` is changed to solve this problem.