### PR TITLE
Remove UnityEngine.AssetGraph/SavedSettings* from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 UnityEngine.AssetGraph/Cache*
-UnityEngine.AssetGraph/SavedSettings*
 UnityEngine.AssetGraph/TemporalSettingFiles*
 UnityEngine.AssetGraph/Generated*
 Doxyfile.meta


### PR DESCRIPTION
According to the [[JP]AssetBundle Graph Tool Document (v1.4)](https://docs.google.com/document/d/1yTkHZch5EaDBCria6I3Xy5UtqrfFx8n9jU1WHre-w0U/edit) , `SavedSettings*` must be under git control.

> コミットすべきもの（バージョン管理すべきファイル）
> SavedSettings 以下の全てのファイル

So I Removed `UnityEngine.AssetGraph/SavedSettings*` from `.gitignore` .